### PR TITLE
Bump flex to ^1.17, v1.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"symfony/console": "^5.3",
 		"symfony/dotenv": "^5.3",
 		"symfony/expression-language": "^5.3",
-		"symfony/flex": "^1.13",
+		"symfony/flex": "^1.17",
 		"symfony/form": "^5.3",
 		"symfony/framework-bundle": "^5.3",
 		"symfony/http-client": "^5.3",


### PR DESCRIPTION
https://symfony.com/blog/the-old-flex-infrastructure-is-shutting-down